### PR TITLE
fix: the value of g3::PI is a constant expression.

### DIFF
--- a/src/Mat.h
+++ b/src/Mat.h
@@ -202,7 +202,7 @@ Mat4 createTranslationMatrix(const float valX, const float valY, const float val
 /**
  * PI constant
  */
-const float PI = 3.14159265358979;
+constexpr float PI = 3.14159265358979;
 
 /**
  * Converts degrees to radians.


### PR DESCRIPTION
`Mat.h:` In function 「`constexpr float g3::toRad(float)`」, the value of 「`g3::PI`」 is not usable in a constant expression. It needs to be  a constant expression.